### PR TITLE
Upgrade this boilerplate to be ParcelV2 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
-.cache
+.parcel-cache
 .vscode
 *.lock
+package-lock.json

--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,4 @@
+{
+  "extends": ["@parcel/config-default"],
+  "reporters":  ["...", "parcel-reporter-static-files-copy"]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "rm -rf ./dist; parcel build src/index.html --public-url '.' --no-source-maps"
   },
   "devDependencies": {
-    "@parcel/transformer-glsl": "^2.7.0",
     "cssnano": "^4.1.10",
     "glslify-bundle": "^5.1.1",
     "glslify-deps": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "parcel serve src/index.html --port 8080 --open",
+    "start": "parcel serve src/index.html --port 8081 --open",
     "build": "rm -rf ./dist; parcel build src/index.html --public-url '.' --no-source-maps"
   },
   "devDependencies": {
+    "@parcel/transformer-glsl": "^2.7.0",
     "cssnano": "^4.1.10",
     "glslify-bundle": "^5.1.1",
     "glslify-deps": "^1.3.2",
-    "parcel-bundler": "1.12.3",
-    "parcel-plugin-static-files-copy": "^2.5.1"
+    "parcel": "^2.7.0",
+    "parcel-reporter-static-files-copy": "^1.4.0"
   },
   "dependencies": {
     "gsap": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "parcel serve src/index.html --port 8081 --open",
+    "start": "parcel serve src/index.html --port 8080 --open",
     "build": "rm -rf ./dist; parcel build src/index.html --public-url '.' --no-source-maps"
   },
   "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
   <link href="./style.css" rel="stylesheet" />
 </head>
 <body>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
FYI, `parcel-bundler` is now totally deprecated. Unused package now and it is upgraded to `parcel` package only but with version 2. `parcel-plugin-static-files-copy` changed to `parcel-reporter-static-files-copy` due to ParcelV2 changed compatible.