### PR TITLE
Owner forgot to adjust script type="module" in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
   <link href="./style.css" rel="stylesheet" />
 </head>
 <body>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
According to the previous PR on #2 , you forgot to add in `index.html` at line `10` to make it as so:
```html
<script type="module" src="index.js"></script>
```

> Due to ParcelV2 changes, any ESM project must have a `type` attribute on setting it to `module` based. You can refer more info here: [Parcel Module](https://parceljs.org/getting-started/migration/#%3Cscript-type%3D%22module%22%3E)

To make your work easier, please merge this Pull Request, and have a nice day! 🥳 